### PR TITLE
[TASK-2]:  Serve SPA in AWS S3 and Cloudfront Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # shop-react-redux-cloudfront
 CloudX: AWS Practitioner for JS
+
+
+***S3 LINK:***
+http://my-ecomm-shop.s3-website-us-east-1.amazonaws.com/
+
+***CLOUDFRONT URL:***
+https://di49h6urwx5vq.cloudfront.net/

--- a/package.json
+++ b/package.json
@@ -37,12 +37,14 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
+    "serverless-single-page-app-plugin": "^1.0.4",
     "yup": "^0.32.11"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.1",
+    "@types/node": "^18.11.17",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
@@ -69,5 +71,17 @@
   },
   "engines": {
     "node": ">=14.0.0"
-  }
+  },
+  "description": "CloudX: AWS Practitioner for JS",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ArtsiomRymarchuk/shop-react-redux-cloudfront.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ArtsiomRymarchuk/shop-react-redux-cloudfront/issues"
+  },
+  "homepage": "https://github.com/ArtsiomRymarchuk/shop-react-redux-cloudfront#readme"
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,0 +1,27 @@
+service: my-store-app
+
+frameworkVersion: "3"
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  region: us-east-1
+
+plugins:
+  - serverless-finch
+  - serverless-single-page-app-plugin
+  - serverless-s3-cleaner
+
+custom:
+  client:
+    bucketName: my-ecomm-sls
+    distributionFolder: dist
+  s3BucketName: ${self:custom.client.bucketName}
+  s3LocalPath: ${self:custom.client.distributionFolder}/
+  serverless-s3-cleaner:
+    buckets:
+      - ${self:custom.client.bucketName}
+
+resources:
+  - ${file(./sls/s3.yml)}
+  - ${file(./sls/cloudfront.yml)}

--- a/sls/cloudfront.yml
+++ b/sls/cloudfront.yml
@@ -1,0 +1,46 @@
+Resources:
+  OriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: Access identity between CloudFront and S3 bucket
+
+  WebAppCloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Origins:
+          - DomainName: !GetAtt WebAppS3Bucket.RegionalDomainName
+            Id: myS3Origin
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${OriginAccessIdentity}
+        Enabled: true
+        IPV6Enabled: true
+        HttpVersion: http2
+        DefaultRootObject: index.html
+        CustomErrorResponses:
+          - ErrorCode: 404
+            ResponseCode: 200
+            ResponsePagePath: /index.html
+        DefaultCacheBehavior:
+          AllowedMethods: ["GET", "HEAD", "OPTIONS"]
+          CachedMethods: ["GET", "HEAD", "OPTIONS"]
+          ForwardedValues:
+            Headers:
+              - Access-Control-Request-Headers
+              - Access-Control-Request-Method
+              - Origin
+              - Authorization
+            QueryString: false
+            Cookies:
+              Forward: none
+          TargetOriginId: myS3Origin
+          ViewerProtocolPolicy: redirect-to-https
+          Compress: true
+          DefaultTTL: 0
+        ViewerCertificate:
+          CloudFrontDefaultCertificate: true
+
+Outputs:
+  WebAppCloudFrontDistributionOutput:
+    Value: !GetAtt WebAppCloudFrontDistribution.DomainName

--- a/sls/s3.yml
+++ b/sls/s3.yml
@@ -1,0 +1,31 @@
+Resources:
+  WebAppS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: ${self:custom.s3BucketName}
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: index.html
+
+  WebAppS3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: WebAppS3Bucket
+      PolicyDocument:
+        Statement:
+          - Sid: "AllowCloudFrontAccessIdentity"
+            Effect: Allow
+            Action: s3:GetObject
+            Resource: arn:aws:s3:::${self:custom.s3BucketName}/*
+            Principal:
+              AWS:
+                Fn::Join:
+                  - " "
+                  - - "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity"
+                    - !Ref OriginAccessIdentity
+
+Outputs:
+  WebAppS3BucketOutput:
+    Value: !Ref WebAppS3Bucket


### PR DESCRIPTION
[Task 2 (Serve SPA in AWS S3 and Cloudfront Services)](https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/2_serving_spa/task.md)

What was done?
* `Serverless-finch` and `serverless-single-page-app` plugins were added and configured. 
* The app can be built and deployed by running `npm` script command

URLs:

[S3](http://my-ecomm-shop.s3-website-us-east-1.amazonaws.com/)
[CLOUDFRONT](https://di49h6urwx5vq.cloudfront.net/)

`npm run cloudfront:update:build:deploy:nc` script creates **s3** and **cloudfront** for SPA automatically. 

![image](https://user-images.githubusercontent.com/110971794/209625853-f3bb7ef6-be2c-47b5-bb1f-34034aa46228.png)

![image](https://user-images.githubusercontent.com/110971794/209626031-4e979ce7-8920-4f6e-a270-4a44b45ee988.png)
